### PR TITLE
Fixed heatmap issue when service has 1 layer

### DIFF
--- a/widgets/HeatMap.js
+++ b/widgets/HeatMap.js
@@ -39,7 +39,7 @@ define([
                  'heatmap'
             ].join('-');
             if (!this._heatMapLayers[layerId]) {
-                var serviceURL = r.layer.url + (r.subLayer ? '/' + r.subLayer.id : '');
+                var serviceURL = r.layer.url + (r.subLayer ? '/' + r.subLayer.id : ((r.layer.layerInfos.length === 1) ? '/0' : ''));
                 var heatmapFeatureLayerOptions = {
                     mode: FeatureLayer.MODE_SNAPSHOT,
                     outFields: ['*'],


### PR DESCRIPTION
When a service is added that has only 1 layer, the layer control adds it as a flat item- as if it were a layer.  But the added url is still lacking a layerid. This enables the heatmap toggle to show, but when it is clicked no sublayer id is passed.  This causes the heatmap toggle to not work in this instance.

I added extra logic to account for this case.  If a sublayer id is passed, it is appended to the request url (as it was before).  If no id is passed, and number of layers is 1, then append a /0 to the request url to fetch the single layer.