### PR TITLE
Fixed metadata issue when service has 1 layer

### DIFF
--- a/widgets/MetadataDialog.js
+++ b/widgets/MetadataDialog.js
@@ -72,7 +72,7 @@ define([
          * @return {[type]}       [description]
          */
         _fetchMetadata: function(event) {
-          var url  = event.layer.url + '/' + event.subLayer.id;
+          var url  = event.layer.url + (event.subLayer ? '/' + event.subLayer.id : ((event.layer.layerInfos.length === 1) ? '/0' : ''));
             new request({
                     url: url,
                     content: {


### PR DESCRIPTION
When a service is added that has only 1 layer, the layer control adds it as a flat item- as if it were a layer.  But the added url is still lacking a layerid. This enables the metadata toggle to show, but when it is clicked no sublayer id is passed.  This causes the metadata toggle to not work in this instance.

I added extra logic to account for this case.  If a sublayer id is passed, it is appended to the request url (as it was before).  If no id is passed, and number of layers is 1, then append a /0 to the request url to fetch the single layer.